### PR TITLE
Fixed explore link on home page

### DIFF
--- a/packages/www/app/components/HeroSection.tsx
+++ b/packages/www/app/components/HeroSection.tsx
@@ -65,7 +65,7 @@ export default function HeroSection() {
         </p>
         <div className="space-y-4 sm:space-y-0 sm:space-x-4 flex flex-col sm:flex-row">
           <a
-            href="#"
+            href="https://docs.data-river.dev"
             className="px-8 py-3 text-lg font-semibold text-white bg-blue-600 rounded-full hover:bg-blue-700 transition duration-300 ease-in-out transform hover:-translate-y-1 hover:shadow-lg"
           >
             Jump In and Explore


### PR DESCRIPTION
### Context and Justification 🌍

Issue: https://github.com/softflow24/data-river/issues/96


### Modifications 🔧

This PR fixes the "Jump in and Explore" link on the home page so that it redirects to https://docs.data-river.dev/.

### Contribution Checklist 📋

<!--
1. Ensure the changes are not duplicating existing issues, PRs, or efforts.
2. Keep changes focused and avoid unnecessary adjustments.
3. Document all relevant changes thoroughly and clearly.
4. If introducing a feature, ensure corresponding tests and documentation are provided.
5. Consider non-code contributions as well, such as improving documentation or suggesting new features.
-->

- [x] Have you used this PR template? &ensp; `+2 pts`
- [x] Is this PR focused on a single, clearly defined change? &ensp; `+5 pts`
- [x ] Have you linked the issue(s) this PR resolves? &ensp; `+5 pts`
- [x ] Are your changes well-documented and easy to follow? &ensp; `+5 pts`
- [ ] Have you introduced a new feature? &ensp; `-4 pts`
  - [ ] Have you updated/added relevant documentation for it? &ensp; `+4 pts`
  - [ ] Have you included tests to ensure it works as expected? &ensp; `+5 pts`
- [ ] Did you alter any core behavior of **data-river**? &ensp; `-5 pts`
  - [x ] Have you tested the changes thoroughly, ensuring no regressions? &ensp; `+10 pts`